### PR TITLE
Refactors build task to use concurrent build and watch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
 			"outFiles": [
 				"${workspaceFolder}/packages/extension/out/**/*.js"
 			],
-			"preLaunchTask": "build-all"
+			"preLaunchTask": "build-and-watch"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,13 +14,31 @@
 			}
 		},
 		{
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": "$tsc-watch",
+			"label": "watch-all",
+			"type": "shell",
+			"command": "pnpm dev",
 			"isBackground": true,
+			"problemMatcher": {
+				"owner": "watch-all",
+				"pattern": {
+					"regexp": "^x^"
+				},
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": ".",
+					"endsPattern": "."
+				}
+			},
 			"presentation": {
-				"reveal": "never"
+				"reveal": "never",
+				"panel": "dedicated",
+				"clear": false
 			}
+		},
+		{
+			"label": "build-and-watch",
+			"dependsOn": ["build-all", "watch-all"],
+			"dependsOrder": "sequence"
 		}
 	]
 }


### PR DESCRIPTION
Updates the build process to run the initial build and the watcher concurrently using pnpm's "dev" script.

This improves the development experience by starting the watcher immediately after the initial build, enabling faster feedback loops.