### PR TITLE
Feature/graph phase 2

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,6 +92,14 @@ export async function activate(context: vscode.ExtensionContext) {
           console.error('Dependency scan failed during activation:', err?.message ?? String(err));
         }
 
+        // Also refresh 90-day Git metrics in the background (non-blocking)
+        try {
+          const { ensureGitMetrics } = await import('./services/git-metrics.service.js');
+          void ensureGitMetrics(context);
+        } catch (err: any) {
+          console.warn('Git metrics refresh failed during activation:', err?.message ?? String(err));
+        }
+
         // Commands
         context.subscriptions.push(
           vscode.commands.registerCommand("constellation.openUserMcpConfig", async () => {

--- a/src/services/git-metrics.service.ts
+++ b/src/services/git-metrics.service.ts
@@ -1,0 +1,224 @@
+import * as vscode from 'vscode'
+import * as fs from 'fs'
+import * as path from 'path'
+import { spawn } from 'child_process'
+import { getWorkspaceRoot } from './workspace.service.js'
+
+export interface FileGitMetrics90d {
+  commitCount: number
+  churn: number // additions + deletions
+  lastModifiedAt: number | null // unix seconds
+  authorCount: number
+  primaryAuthor?: string
+}
+
+export interface GitMetricsEnvelope {
+  version: 1
+  horizonDays: number
+  head: string | null
+  repoRoot: string | null
+  workspaceRoot: string
+  generatedAt: string
+  available: boolean
+  metrics: Record<string, FileGitMetrics90d>
+}
+
+const METRICS_FILENAME = 'git-metrics.json'
+const HORIZON_DAYS = 90
+
+function getOutputDir(workspaceRoot: string) {
+  return path.join(workspaceRoot, '.constellation', 'data')
+}
+
+function getMetricsPath(workspaceRoot: string) {
+  return path.join(getOutputDir(workspaceRoot), METRICS_FILENAME)
+}
+
+async function runGit(cwd: string, args: string[]): Promise<{ code: number, stdout: string, stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] })
+    const out: string[] = []
+    const err: string[] = []
+    child.stdout.on('data', (b: Buffer) => out.push(b.toString()))
+    child.stderr.on('data', (b: Buffer) => err.push(b.toString()))
+    child.on('close', (code) => {
+      resolve({ code: code ?? 0, stdout: out.join(''), stderr: err.join('') })
+    })
+    child.on('error', () => {
+      resolve({ code: 127, stdout: '', stderr: 'failed to spawn git' })
+    })
+  })
+}
+
+async function detectRepoRoot(cwd: string): Promise<string | null> {
+  const res = await runGit(cwd, ['rev-parse', '--show-toplevel'])
+  if (res.code !== 0) return null
+  return res.stdout.trim()
+}
+
+async function getHead(cwd: string): Promise<string | null> {
+  const res = await runGit(cwd, ['rev-parse', 'HEAD'])
+  if (res.code !== 0) return null
+  return res.stdout.trim()
+}
+
+function readExisting(workspaceRoot: string): GitMetricsEnvelope | null {
+  try {
+    const p = getMetricsPath(workspaceRoot)
+    if (!fs.existsSync(p)) return null
+    const raw = fs.readFileSync(p, 'utf8')
+    const json = JSON.parse(raw)
+    // basic shape check
+    if (!json || typeof json !== 'object' || typeof json.metrics !== 'object') return null
+    return json as GitMetricsEnvelope
+  } catch {
+    return null
+  }
+}
+
+function writeEnvelope(workspaceRoot: string, env: GitMetricsEnvelope) {
+  const dir = getOutputDir(workspaceRoot)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(getMetricsPath(workspaceRoot), JSON.stringify(env, null, 2), 'utf8')
+}
+
+export async function readGitMetrics(context: vscode.ExtensionContext): Promise<GitMetricsEnvelope | null> {
+  const workspaceRoot = getWorkspaceRoot()
+  if (!workspaceRoot) return null
+  return readExisting(workspaceRoot)
+}
+
+export async function ensureGitMetrics(context: vscode.ExtensionContext): Promise<GitMetricsEnvelope | null> {
+  const workspaceRoot = getWorkspaceRoot()
+  if (!workspaceRoot) return null
+
+  // Detect repo
+  const repoRoot = await detectRepoRoot(workspaceRoot)
+  if (!repoRoot) {
+    // Not a git repo — write sentinel envelope so UI can show "no git"
+    const sentinel: GitMetricsEnvelope = {
+      version: 1,
+      horizonDays: HORIZON_DAYS,
+      head: null,
+      repoRoot: null,
+      workspaceRoot,
+      generatedAt: new Date().toISOString(),
+      available: false,
+      metrics: {}
+    }
+    writeEnvelope(workspaceRoot, sentinel)
+    return sentinel
+  }
+
+  // Check cache
+  const head = await getHead(repoRoot)
+  const existing = readExisting(workspaceRoot)
+  if (existing && existing.available && existing.head === head && existing.horizonDays === HORIZON_DAYS) {
+    return existing
+  }
+
+  // Compute fresh metrics (90-day window)
+  const args = [
+    'log',
+    `--since=${HORIZON_DAYS}.days`,
+    '--no-merges',
+    '--no-renames',
+    '--numstat',
+    '--format=%H%x09%at%x09%an'
+  ]
+  const { code, stdout } = await runGit(repoRoot, args)
+  if (code !== 0) {
+    const fallback: GitMetricsEnvelope = {
+      version: 1,
+      horizonDays: HORIZON_DAYS,
+      head,
+      repoRoot,
+      workspaceRoot,
+      generatedAt: new Date().toISOString(),
+      available: false,
+      metrics: {}
+    }
+    writeEnvelope(workspaceRoot, fallback)
+    return fallback
+  }
+
+  type Acc = {
+    commitCount: number
+    churn: number
+    lastModifiedAt: number | null
+    authors: Map<string, number>
+  }
+
+  const byFile: Map<string, Acc> = new Map()
+
+  let currentTs: number | null = null
+  let currentAuthor: string | null = null
+
+  const lines = stdout.split(/\r?\n/)
+  const commitHeaderRe = /^([0-9a-fA-F]{7,40})\t(\d{1,})\t(.+)$/
+  const numstatRe = /^(\d+|-)\t(\d+|-)\t(.+)$/
+
+  for (const line of lines) {
+    if (!line) continue
+    const mHeader = commitHeaderRe.exec(line)
+    if (mHeader) {
+      currentTs = parseInt(mHeader[2], 10) || null
+      currentAuthor = mHeader[3]
+      continue
+    }
+    const mNum = numstatRe.exec(line)
+    if (!mNum) continue
+
+    // Require a current commit context
+    if (currentTs == null || !currentAuthor) continue
+
+    const adds = mNum[1] === '-' ? 0 : parseInt(mNum[1], 10)
+    const dels = mNum[2] === '-' ? 0 : parseInt(mNum[2], 10)
+    const relPathFromRepo = mNum[3]
+
+    // Normalize to workspace-relative id (align with GraphData node ids)
+    const abs = path.resolve(repoRoot, relPathFromRepo)
+    let rel = path.relative(workspaceRoot, abs).split(path.sep).join(path.posix.sep)
+    if (rel.startsWith('..')) {
+      // File outside workspace root; ignore
+      continue
+    }
+
+    const prev = byFile.get(rel) ?? { commitCount: 0, churn: 0, lastModifiedAt: null, authors: new Map<string, number>() }
+    prev.commitCount += 1
+    prev.churn += (adds + dels)
+    prev.lastModifiedAt = Math.max(prev.lastModifiedAt ?? 0, currentTs)
+    prev.authors.set(currentAuthor, (prev.authors.get(currentAuthor) ?? 0) + 1)
+    byFile.set(rel, prev)
+  }
+
+  const metrics: Record<string, FileGitMetrics90d> = {}
+  for (const [rel, acc] of byFile.entries()) {
+    let primaryAuthor: string | undefined
+    let maxCommits = -1
+    for (const [author, count] of acc.authors.entries()) {
+      if (count > maxCommits) { maxCommits = count; primaryAuthor = author }
+    }
+    metrics[rel] = {
+      commitCount: acc.commitCount,
+      churn: acc.churn,
+      lastModifiedAt: acc.lastModifiedAt,
+      authorCount: acc.authors.size,
+      primaryAuthor
+    }
+  }
+
+  const envelope: GitMetricsEnvelope = {
+    version: 1,
+    horizonDays: HORIZON_DAYS,
+    head,
+    repoRoot,
+    workspaceRoot,
+    generatedAt: new Date().toISOString(),
+    available: true,
+    metrics
+  }
+
+  writeEnvelope(workspaceRoot, envelope)
+  return envelope
+}

--- a/webview-ui/src/components/FileInfoPanel.tsx
+++ b/webview-ui/src/components/FileInfoPanel.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from 'preact/hooks'
+
+interface FileGitMetrics90d {
+  commitCount: number
+  churn: number
+  lastModifiedAt: number | null
+  authorCount: number
+  primaryAuthor?: string
+}
+
+interface NodeInfoPanelProps {
+  nodeId: string
+  node: { id: string; label: string; path: string } | null
+  inDegree: number
+  outDegree: number
+  metrics?: FileGitMetrics90d
+  metricsReady?: boolean
+  onOpenFile: () => void
+  onClose: () => void
+}
+
+function formatRelative(ts: number | null): string {
+  if (!ts) return '—'
+  const now = Date.now()
+  const d = new Date(ts * 1000)
+  const diff = Math.floor((now - d.getTime()) / (1000 * 60)) // minutes
+  if (diff < 60) return `${diff}m ago`
+  const hours = Math.floor(diff / 60)
+  if (hours < 48) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 60) return `${days}d ago`
+  return d.toLocaleDateString()
+}
+
+export function FileInfoPanel({ nodeId, node, inDegree, outDegree, metrics, metricsReady, onOpenFile, onClose }: NodeInfoPanelProps) {
+  const title = node?.label || nodeId.split('/').slice(-1)[0]
+  const pathText = node?.id || nodeId
+
+  const metricItems = useMemo(() => {
+    if (!metricsReady) return 'loading'
+    if (!metrics) return 'none'
+    return 'ok'
+  }, [metricsReady, metrics])
+
+  return (
+    <div className="file-info-panel" role="dialog" aria-label="File details">
+      <div className="file-info-header">
+        <div className="file-info-titles">
+          <div className="file-info-title">{title}</div>
+          <div className="file-info-path" title={pathText}>{pathText}</div>
+        </div>
+        <button className="btn btn-ghost btn-sm file-info-close" aria-label="Close" onClick={onClose}>×</button>
+      </div>
+
+      <div className="file-info-section">
+        <div className="file-info-stat"><span className="label">Imports</span><span className="value">{outDegree}</span></div>
+        <div className="file-info-stat"><span className="label">Imported by</span><span className="value">{inDegree}</span></div>
+      </div>
+
+      <div className="file-info-section">
+        <div className="file-info-section-title">Git (90 days)</div>
+        {metricItems === 'loading' && (
+          <div className="file-info-empty">Loading metrics…</div>
+        )}
+        {metricItems === 'none' && (
+          <div className="file-info-empty">No Git data available</div>
+        )}
+        {metricItems === 'ok' && metrics && (
+          <div className="file-info-grid">
+            <div className="file-info-stat"><span className="label">Commits</span><span className="value">{metrics.commitCount}</span></div>
+            <div className="file-info-stat"><span className="label">Churn</span><span className="value">{metrics.churn}</span></div>
+            <div className="file-info-stat"><span className="label">Authors</span><span className="value">{metrics.authorCount}</span></div>
+            <div className="file-info-stat"><span className="label">Last change</span><span className="value">{formatRelative(metrics.lastModifiedAt)}</span></div>
+            {metrics.primaryAuthor && (
+              <div className="file-info-stat"><span className="label">Primary</span><span className="value">{metrics.primaryAuthor}</span></div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="file-info-actions">
+        <button className="btn btn-primary btn-sm" onClick={onOpenFile}>Open file</button>
+      </div>
+    </div>
+  )
+}

--- a/webview-ui/src/components/GraphCanvas.tsx
+++ b/webview-ui/src/components/GraphCanvas.tsx
@@ -52,10 +52,11 @@ interface GraphCanvasProps {
   onRenderingChange: (rendering: boolean) => void
   impactSourceId?: string
   onNodeDrill?: (nodeId: string) => void
+  onNodeSelect?: (nodeId: string) => void
 }
 
 export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
-  ({ data, isRendering, onRenderingChange, impactSourceId, onNodeDrill }, ref) => {
+  ({ data, isRendering, onRenderingChange, impactSourceId, onNodeDrill, onNodeSelect }, ref) => {
     const containerRef = useRef<HTMLDivElement>(null)
     const cyRef = useRef<Core | null>(null)
     // Keep a stable reference to the callback so the effect below doesn't re-run
@@ -280,7 +281,9 @@ export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
           cyRef.current.on('tap', 'node', (evt) => {
             // Single-click highlighting (node gets selected automatically by Cytoscape)
             const node = evt.target
-            console.log('Node selected:', node.data('label'))
+            const nodeId = node.id()
+            if (onNodeSelect) onNodeSelect(nodeId)
+            else console.log('Node selected:', node.data('label'))
           })
 
           cyRef.current.on('dbltap', 'node', (evt) => {

--- a/webview-ui/src/components/GraphCanvas.tsx
+++ b/webview-ui/src/components/GraphCanvas.tsx
@@ -59,6 +59,7 @@ export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
   ({ data, isRendering, onRenderingChange, impactSourceId, onNodeDrill, onNodeSelect }, ref) => {
     const containerRef = useRef<HTMLDivElement>(null)
     const cyRef = useRef<Core | null>(null)
+    const tapTimeoutRef = useRef<number | null>(null)
     // Keep a stable reference to the callback so the effect below doesn't re-run
     const onRenderingChangeRef = useRef(onRenderingChange)
     useEffect(() => { onRenderingChangeRef.current = onRenderingChange }, [onRenderingChange])
@@ -279,14 +280,26 @@ export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
 
           // Add event handlers for interactions
           cyRef.current.on('tap', 'node', (evt) => {
-            // Single-click highlighting (node gets selected automatically by Cytoscape)
+            // Delay selection slightly to allow dbltap to cancel it
             const node = evt.target
             const nodeId = node.id()
-            if (onNodeSelect) onNodeSelect(nodeId)
-            else console.log('Node selected:', node.data('label'))
+            if (tapTimeoutRef.current) {
+              window.clearTimeout(tapTimeoutRef.current)
+              tapTimeoutRef.current = null
+            }
+            tapTimeoutRef.current = window.setTimeout(() => {
+              if (onNodeSelect) onNodeSelect(nodeId)
+              else console.log('Node selected:', node.data('label'))
+              tapTimeoutRef.current = null
+            }, 220)
           })
 
           cyRef.current.on('dbltap', 'node', (evt) => {
+            // Cancel pending single-selection
+            if (tapTimeoutRef.current) {
+              window.clearTimeout(tapTimeoutRef.current)
+              tapTimeoutRef.current = null
+            }
             const node = evt.target
             const nodeId = node.id()
             const path = node.data('path')
@@ -320,6 +333,10 @@ export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
   // Enhanced cleanup on unmount
   useEffect(() => {
     return () => {
+      if (tapTimeoutRef.current) {
+        window.clearTimeout(tapTimeoutRef.current)
+        tapTimeoutRef.current = null
+      }
       if (cyRef.current) {
         try {
           // Remove all event listeners before destroying

--- a/webview-ui/src/services/messenger.ts
+++ b/webview-ui/src/services/messenger.ts
@@ -14,6 +14,7 @@ type GraphResponseMessage =
   | { type: 'graph/error'; message: string }
   | { type: 'graph/status'; message: string }
   | { type: 'graph/impact'; payload: { sourceFile: string; affectedFiles: string[] } }
+  | { type: 'graph/metrics'; payload: { horizonDays: number; available: boolean; metrics: Record<string, { commitCount: number; churn: number; lastModifiedAt: number | null; authorCount: number; primaryAuthor?: string }> } }
 
 // Onboarding-specific message types for webview -> extension
 type OnboardingMessage =

--- a/webview-ui/src/styles/global.css
+++ b/webview-ui/src/styles/global.css
@@ -367,6 +367,94 @@ body {
   font-size: 12px;
 }
 
+/* File Info Panel */
+.file-info-panel {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2000;
+  width: 320px;
+  max-width: calc(100% - 24px);
+  background: var(--kiro-surface-1);
+  border: 1px solid var(--kiro-border);
+  border-radius: var(--kiro-radius-2);
+  box-shadow: var(--kiro-shadow-soft);
+  display: flex;
+  flex-direction: column;
+}
+
+.file-info-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--kiro-border);
+}
+
+.file-info-titles {
+  min-width: 0;
+}
+
+.file-info-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--kiro-text);
+  margin-bottom: 2px;
+}
+
+.file-info-path {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+  color: var(--kiro-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 240px;
+}
+
+.file-info-close {
+  line-height: 1;
+}
+
+.file-info-section {
+  padding: 8px 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 12px;
+}
+
+.file-info-section-title {
+  grid-column: 1 / -1;
+  font-size: 12px;
+  color: var(--kiro-text-muted);
+  margin-bottom: 4px;
+}
+
+.file-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 12px;
+  grid-column: 1 / -1;
+}
+
+.file-info-stat { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.file-info-stat .label { font-size: 11px; color: var(--kiro-text-muted); }
+.file-info-stat .value { font-size: 12px; color: var(--kiro-text); font-weight: 500; }
+
+.file-info-empty {
+  grid-column: 1 / -1;
+  font-size: 12px;
+  color: var(--kiro-text-muted);
+}
+
+.file-info-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 8px 10px 10px 10px;
+  border-top: 1px solid var(--kiro-border);
+}
+
 /* Focus and Keyboard Navigation */
 .toolbar-input:focus,
 .toolbar-button:focus,


### PR DESCRIPTION
This pull request adds a new feature to display per-file Git metrics (over the past 90 days) in the file info panel of the dependency graph UI. It introduces backend logic to compute and cache these metrics, extends the messaging protocol to deliver them to the webview, and updates the UI to show the data in a new panel when selecting a file node. The implementation is robust to missing or unavailable Git data and includes a new design for the info panel.

**Backend: Git Metrics Calculation and Delivery**
- Added a new service (`git-metrics.service.ts`) to compute, cache, and serve per-file Git metrics (commit count, churn, last modified time, author count, primary author) for the last 90 days. Metrics are computed using `git log` and cached in `.constellation/data/git-metrics.json`. The service is invoked on extension activation and graph scan, and gracefully handles missing or non-git workspaces. [[1]](diffhunk://#diff-63d0df21b6e92304818775339b0a680749ba5a45d1b09ef2223f6a35449cf01cR1-R224) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R95-R102)
- Extended the extension-webview messaging protocol to support a new `graph/metrics` message type, delivering the metrics envelope to the webview when available. [[1]](diffhunk://#diff-ccd1e84dd18fbcaf6e5902d6ed5c40f30c92ccff454e5b9c79f3a1dcf5172c2bR16) [[2]](diffhunk://#diff-ccd1e84dd18fbcaf6e5902d6ed5c40f30c92ccff454e5b9c79f3a1dcf5172c2bR139-R147) [[3]](diffhunk://#diff-ccd1e84dd18fbcaf6e5902d6ed5c40f30c92ccff454e5b9c79f3a1dcf5172c2bR178-R188) [[4]](diffhunk://#diff-01dd4582077add770a8f4c94beef3dc0d91b9b8321e94ce1458d05c196e05b57R17)

**Frontend: UI Integration and File Info Panel**
- Added a new `FileInfoPanel` component that displays file details, including the new Git metrics, in a styled panel anchored to the top-right of the graph UI. The panel shows loading, unavailable, or actual metric states and supports opening the file or closing the panel. [[1]](diffhunk://#diff-2991347ece73a3ea6e10966ca65b3ee03017b21b09bde73f10dc4f0ab882dd27R1-R86) [[2]](diffhunk://#diff-c259cc6fad2883427fbec1cdde24db3c75cdf444d8e32dee304e3fe886a3d5b4R370-R457)
- Updated `GraphDashboard` to track the selected node, manage Git metrics state, and display the `FileInfoPanel` when a node is selected. The metrics are updated when new data arrives from the extension. [[1]](diffhunk://#diff-e8fa683bb1940629cfaeaeee3223677924c2332ee2844ecd34148f22f6a57ab4R6) [[2]](diffhunk://#diff-e8fa683bb1940629cfaeaeee3223677924c2332ee2844ecd34148f22f6a57ab4R82-R98) [[3]](diffhunk://#diff-e8fa683bb1940629cfaeaeee3223677924c2332ee2844ecd34148f22f6a57ab4R596-R604) [[4]](diffhunk://#diff-e8fa683bb1940629cfaeaeee3223677924c2332ee2844ecd34148f22f6a57ab4R796-R823)

**Frontend: Node Selection Improvements**
- Enhanced `GraphCanvas` to support node selection (single-tap with debounce to avoid clashing with double-tap), triggering the info panel. Cleaned up event listeners and exposed a new `onNodeSelect` prop for parent components. [[1]](diffhunk://#diff-495347297ea0a60a4f3a409db8cd7b4e2f605e480aaff4444da5dc86060e81bbR55-R62) [[2]](diffhunk://#diff-495347297ea0a60a4f3a409db8cd7b4e2f605e480aaff4444da5dc86060e81bbL281-R302) [[3]](diffhunk://#diff-495347297ea0a60a4f3a409db8cd7b4e2f605e480aaff4444da5dc86060e81bbR336-R339)

These changes collectively provide users with actionable Git history insights for each file in the dependency graph, improving the overall usefulness of the visualization.