### PR TITLE
feat(ui): add atom and molecule component library

### DIFF
--- a/webview-ui/src/components/App.tsx
+++ b/webview-ui/src/components/App.tsx
@@ -1,5 +1,6 @@
 import { SidePanelView } from '../views/SidePanelView'
 import { GraphDashboard } from './GraphDashboard'
+import { Playground } from '../views/Playground'
 
 export function App() {
   const root = document.getElementById('root') as HTMLElement | null
@@ -7,6 +8,9 @@ export function App() {
 
   if (view === 'graph') {
     return <GraphDashboard />
+  }
+  if (view === 'playground') {
+    return <Playground />
   }
   return <SidePanelView />
 }

--- a/webview-ui/src/components/atoms/ButtonIcon.tsx
+++ b/webview-ui/src/components/atoms/ButtonIcon.tsx
@@ -1,0 +1,21 @@
+import { Icon, type IconName } from './Icon'
+
+interface ButtonIconProps {
+  iconName: IconName
+  onClick: () => void
+  disabled?: boolean
+  ariaLabel: string
+}
+
+export function ButtonIcon({ iconName, onClick, disabled, ariaLabel }: ButtonIconProps) {
+  return (
+    <button
+      class="button-icon"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <Icon name={iconName} size={20} colorToken="--text-primary" />
+    </button>
+  )
+}

--- a/webview-ui/src/components/atoms/ButtonLink.tsx
+++ b/webview-ui/src/components/atoms/ButtonLink.tsx
@@ -1,0 +1,28 @@
+import type { ComponentChildren } from 'preact'
+
+interface ButtonLinkProps {
+  children: ComponentChildren
+  onClick?: () => void
+  href?: string
+  disabled?: boolean
+}
+
+export function ButtonLink({ children, onClick, href, disabled }: ButtonLinkProps) {
+  if (href) {
+    return (
+      <a
+        class="button-link"
+        href={href}
+        onClick={onClick}
+        aria-disabled={disabled}
+      >
+        {children}
+      </a>
+    )
+  }
+  return (
+    <button class="button-link" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  )
+}

--- a/webview-ui/src/components/atoms/Chip.tsx
+++ b/webview-ui/src/components/atoms/Chip.tsx
@@ -1,0 +1,32 @@
+import type { JSX } from 'preact'
+
+interface ChipProps {
+  label: string
+  variant: 'brand' | 'success'
+  onClick?: () => void
+  selected?: boolean
+  ariaPressed?: boolean
+}
+
+export function Chip({ label, variant, onClick, selected, ariaPressed }: ChipProps) {
+  const bg = variant === 'brand' ? 'var(--surface-tint-brand)' : 'var(--surface-tint-success)'
+  const color = variant === 'brand' ? 'var(--accent-purple-soft-text)' : 'var(--accent-green-soft-text)'
+  return (
+    <button
+      class="chip"
+      style={{
+        background: bg,
+        color,
+        padding: '0 12px',
+        height: '28px',
+        borderRadius: 'var(--radius-chip)',
+        border: 'none',
+        cursor: onClick ? 'pointer' : 'default'
+      }}
+      onClick={onClick}
+      aria-pressed={ariaPressed ?? selected}
+    >
+      {label}
+    </button>
+  )
+}

--- a/webview-ui/src/components/atoms/DividerLine.tsx
+++ b/webview-ui/src/components/atoms/DividerLine.tsx
@@ -1,0 +1,10 @@
+interface DividerLineProps {
+  orientation?: 'horizontal' | 'vertical'
+}
+
+export function DividerLine({ orientation = 'horizontal' }: DividerLineProps) {
+  if (orientation === 'vertical') {
+    return <div style={{ width: '1px', background: 'var(--surface-overlay-08)', alignSelf: 'stretch' }} />
+  }
+  return <hr style={{ border: 'none', borderTop: '1px solid var(--surface-overlay-08)' }} />
+}

--- a/webview-ui/src/components/atoms/Icon.tsx
+++ b/webview-ui/src/components/atoms/Icon.tsx
@@ -1,0 +1,70 @@
+import type { JSX } from 'preact'
+
+const paths: Record<string, JSX.Element> = {
+  search: (
+    <>
+      <circle cx="11" cy="11" r="6" stroke-width="2" />
+      <line x1="16" y1="16" x2="22" y2="22" stroke-width="2" />
+    </>
+  ),
+  'chevron-down': <polyline points="6 9 12 15 18 9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />, 
+  'chevron-right': <polyline points="9 6 15 12 9 18" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />, 
+  help: (
+    <>
+      <circle cx="12" cy="12" r="10" stroke-width="2" />
+      <path d="M9 9a3 3 0 116 0c0 2-3 2-3 5" fill="none" stroke-width="2" stroke-linecap="round" />
+      <circle cx="12" cy="17" r="1" />
+    </>
+  ),
+  check: <polyline points="5 13 9 17 19 7" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />, 
+  plus: <g stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></g>,
+  minus: <line x1="5" y1="12" x2="19" y2="12" stroke-width="2" stroke-linecap="round" />, 
+  fullscreen: (
+    <>
+      <polyline points="3 9 3 3 9 3" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline points="15 3 21 3 21 9" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline points="21 15 21 21 15 21" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline points="9 21 3 21 3 15" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+    </>
+  ),
+  clock: (
+    <>
+      <circle cx="12" cy="12" r="10" stroke-width="2" />
+      <polyline points="12 6 12 12 16 14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    </>
+  ),
+  settings: (
+    <>
+      <circle cx="12" cy="12" r="3" stroke-width="2" />
+      <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09a1.65 1.65 0 00-1-1.51 1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09a1.65 1.65 0 001.51-1 1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06a1.65 1.65 0 001.82.33h.06A1.65 1.65 0 0011 3.09V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51h.06a1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82v.06A1.65 1.65 0 0020.91 11H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+    </>
+  )
+}
+
+export type IconName = keyof typeof paths
+
+interface IconProps {
+  name: IconName
+  size?: 16 | 20 | 24
+  colorToken?: string
+  title?: string
+}
+
+export function Icon({ name, size = 16, colorToken = '--text-secondary', title }: IconProps) {
+  const path = paths[name]
+  if (!path) return null
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      style={{ color: `var(${colorToken})` }}
+      aria-hidden={title ? undefined : 'true'}
+    >
+      {title ? <title>{title}</title> : null}
+      {path}
+    </svg>
+  )
+}

--- a/webview-ui/src/components/atoms/IconTile.tsx
+++ b/webview-ui/src/components/atoms/IconTile.tsx
@@ -1,0 +1,27 @@
+import { Icon, type IconName } from './Icon'
+
+interface IconTileProps {
+  variant: 'brand' | 'success'
+  iconName: IconName
+  size?: number
+}
+
+export function IconTile({ variant, iconName, size = 48 }: IconTileProps) {
+  const bg = variant === 'brand' ? 'var(--surface-tint-brand)' : 'var(--surface-tint-success)'
+  const color = variant === 'brand' ? '--accent-brand' : '--accent-success'
+  return (
+    <div
+      style={{
+        width: `${size}px`,
+        height: `${size}px`,
+        borderRadius: 'var(--radius-tile)',
+        background: bg,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}
+    >
+      <Icon name={iconName} size={24} colorToken={color} />
+    </div>
+  )
+}

--- a/webview-ui/src/components/atoms/InputField.tsx
+++ b/webview-ui/src/components/atoms/InputField.tsx
@@ -1,0 +1,27 @@
+import { Icon, type IconName } from './Icon'
+import type { ComponentChildren } from 'preact'
+
+interface InputFieldProps {
+  value: string
+  placeholder?: string
+  onChange: (value: string) => void
+  leadingIcon?: IconName
+  trailingSlot?: ComponentChildren
+  ariaLabel: string
+}
+
+export function InputField({ value, placeholder, onChange, leadingIcon, trailingSlot, ariaLabel }: InputFieldProps) {
+  return (
+    <div class="input-field">
+      {leadingIcon && <Icon name={leadingIcon} size={20} colorToken="--text-secondary" />}
+      <input
+        class="input-field-input"
+        value={value}
+        placeholder={placeholder}
+        onInput={e => onChange((e.target as HTMLInputElement).value)}
+        aria-label={ariaLabel}
+      />
+      {trailingSlot}
+    </div>
+  )
+}

--- a/webview-ui/src/components/atoms/KeyboardHintPill.tsx
+++ b/webview-ui/src/components/atoms/KeyboardHintPill.tsx
@@ -1,0 +1,11 @@
+interface KeyboardHintPillProps {
+  label: string
+}
+
+export function KeyboardHintPill({ label }: KeyboardHintPillProps) {
+  return (
+    <span class="kbd-pill" aria-hidden="true">
+      {label}
+    </span>
+  )
+}

--- a/webview-ui/src/components/atoms/MetricBullet.tsx
+++ b/webview-ui/src/components/atoms/MetricBullet.tsx
@@ -1,0 +1,21 @@
+interface MetricBulletProps {
+  variant: 'purple' | 'green' | 'neutral'
+  text: string
+}
+
+export function MetricBullet({ variant, text }: MetricBulletProps) {
+  const colorMap = {
+    purple: 'var(--text-link)',
+    green: 'var(--accent-success)',
+    neutral: 'var(--text-secondary)'
+  }
+  return (
+    <span class="metric-bullet">
+      <span
+        class="metric-bullet-dot"
+        style={{ background: colorMap[variant] }}
+      />
+      <span class="metric-bullet-text">{text}</span>
+    </span>
+  )
+}

--- a/webview-ui/src/components/atoms/StatusDot.tsx
+++ b/webview-ui/src/components/atoms/StatusDot.tsx
@@ -1,0 +1,28 @@
+interface StatusDotProps {
+  status: 'healthy' | 'warning' | 'error'
+  size: 8 | 10
+}
+
+export function StatusDot({ status, size }: StatusDotProps) {
+  const colorMap = {
+    healthy: 'var(--accent-success)',
+    warning: 'var(--kiro-warning, #ffcc00)',
+    error: 'var(--kiro-danger, #f48771)'
+  }
+  const shadow =
+    status === 'healthy' ? '0 0 8px rgba(34, 197, 94, 0.35)' : undefined
+  return (
+    <span
+      role="status"
+      aria-label={`status: ${status}`}
+      style={{
+        width: `${size}px`,
+        height: `${size}px`,
+        borderRadius: '50%',
+        background: colorMap[status],
+        boxShadow: shadow,
+        display: 'inline-block'
+      }}
+    />
+  )
+}

--- a/webview-ui/src/components/atoms/Tooltip.tsx
+++ b/webview-ui/src/components/atoms/Tooltip.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'preact/hooks'
+import { cloneElement } from 'preact'
+import type { ComponentChildren, VNode } from 'preact'
+
+interface TooltipProps {
+  content: ComponentChildren
+  children: VNode
+  placement?: 'top' | 'bottom'
+}
+
+export function Tooltip({ content, children, placement = 'top' }: TooltipProps) {
+  const [visible, setVisible] = useState(false)
+
+  const child = cloneElement(children, {
+    onMouseEnter: () => {
+      children.props?.onMouseEnter?.()
+      setVisible(true)
+    },
+    onMouseLeave: () => {
+      children.props?.onMouseLeave?.()
+      setVisible(false)
+    },
+    onFocus: () => {
+      children.props?.onFocus?.()
+      setVisible(true)
+    },
+    onBlur: () => {
+      children.props?.onBlur?.()
+      setVisible(false)
+    }
+  }) as VNode
+
+  return (
+    <span class="tooltip-wrapper" style={{ position: 'relative', display: 'inline-flex' }}>
+      {child}
+      {visible && (
+        <span
+          role="tooltip"
+          class={`tooltip tooltip-${placement}`}
+        >
+          {content}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/webview-ui/src/components/molecules/ActionCard.tsx
+++ b/webview-ui/src/components/molecules/ActionCard.tsx
@@ -1,0 +1,26 @@
+import { IconTile } from '../atoms/IconTile'
+import type { IconName } from '../atoms/Icon'
+import type { ComponentChildren } from 'preact'
+
+interface ActionCardProps {
+  title: string
+  subtitle: string
+  variant: 'brand' | 'success'
+  iconName: IconName
+  onClick?: () => void
+  disabled?: boolean
+  rightSlot?: ComponentChildren
+}
+
+export function ActionCard({ title, subtitle, variant, iconName, onClick, disabled, rightSlot }: ActionCardProps) {
+  return (
+    <button class="action-card" onClick={onClick} disabled={disabled}>
+      <IconTile variant={variant} iconName={iconName} />
+      <div class="action-card-text">
+        <div class="action-card-title">{title}</div>
+        <div class="action-card-subtitle">{subtitle}</div>
+      </div>
+      {rightSlot && <div class="action-card-right">{rightSlot}</div>}
+    </button>
+  )
+}

--- a/webview-ui/src/components/molecules/BreadcrumbItem.tsx
+++ b/webview-ui/src/components/molecules/BreadcrumbItem.tsx
@@ -1,0 +1,20 @@
+import { Icon } from '../atoms/Icon'
+
+interface BreadcrumbItemProps {
+  label: string
+  active?: boolean
+  onClick: () => void
+}
+
+export function BreadcrumbItem({ label, active, onClick }: BreadcrumbItemProps) {
+  return (
+    <button
+      class="breadcrumb-item"
+      onClick={onClick}
+      aria-current={active ? 'page' : undefined}
+    >
+      {label}
+      {!active && <Icon name="chevron-right" size={16} colorToken="--text-secondary" />}
+    </button>
+  )
+}

--- a/webview-ui/src/components/molecules/ChipGroup.tsx
+++ b/webview-ui/src/components/molecules/ChipGroup.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'preact/hooks'
+import { Chip } from '../atoms/Chip'
+
+interface ChipItem {
+  label: string
+  variant: 'brand' | 'success'
+  selected?: boolean
+}
+
+interface ChipGroupProps {
+  chips: ChipItem[]
+  onChange?: (chips: ChipItem[]) => void
+  selectMode?: 'none' | 'single' | 'multi'
+}
+
+export function ChipGroup({ chips, onChange, selectMode = 'none' }: ChipGroupProps) {
+  const [items, setItems] = useState(chips)
+
+  function toggle(index: number) {
+    const updated = items.map((c, i) => {
+      if (i !== index) {
+        return selectMode === 'single' ? { ...c, selected: false } : c
+      }
+      if (selectMode === 'none') return c
+      return { ...c, selected: !c.selected }
+    })
+    setItems(updated)
+    onChange?.(updated)
+  }
+
+  return (
+    <div class="chip-group">
+      {items.map((chip, i) => (
+        <Chip
+          key={i}
+          label={chip.label}
+          variant={chip.variant}
+          onClick={() => toggle(i)}
+          selected={chip.selected}
+        />
+      ))}
+    </div>
+  )
+}

--- a/webview-ui/src/components/molecules/DataStatusCard.tsx
+++ b/webview-ui/src/components/molecules/DataStatusCard.tsx
@@ -1,0 +1,38 @@
+import { IconTile } from '../atoms/IconTile'
+import { Icon } from '../atoms/Icon'
+import { MetricBullet } from '../atoms/MetricBullet'
+import { StatusDot } from '../atoms/StatusDot'
+import { ButtonLink } from '../atoms/ButtonLink'
+
+interface DataStatusCardProps {
+  title: string
+  lastIndexedText: string
+  filesCount: number
+  depsCount: number
+  status: 'healthy' | 'warning' | 'error'
+  onReindex?: () => void
+}
+
+export function DataStatusCard({ title, lastIndexedText, filesCount, depsCount, status, onReindex }: DataStatusCardProps) {
+  return (
+    <div class="data-status-card">
+      <IconTile variant="success" iconName="check" />
+      <div class="data-status-body">
+        <div class="data-status-title">{title}</div>
+        <div class="data-status-subline">
+          <Icon name="clock" size={16} colorToken="--text-secondary" />
+          <span>{lastIndexedText}</span>
+        </div>
+        <div class="data-status-stats">
+          <MetricBullet variant="purple" text={`${filesCount} files`} />
+          <span class="stat-sep">→</span>
+          <MetricBullet variant="green" text={`${depsCount} deps`} />
+          <StatusDot status={status} size={8} />
+        </div>
+        {onReindex && (
+          <ButtonLink onClick={onReindex}>Re-index Now</ButtonLink>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/webview-ui/src/components/molecules/MetricsInline.tsx
+++ b/webview-ui/src/components/molecules/MetricsInline.tsx
@@ -1,0 +1,20 @@
+import { MetricBullet } from '../atoms/MetricBullet'
+
+interface Item { variant: 'purple' | 'green' | 'neutral'; text: string }
+
+interface MetricsInlineProps {
+  items: Item[]
+}
+
+export function MetricsInline({ items }: MetricsInlineProps) {
+  return (
+    <div class="metrics-inline">
+      {items.map((item, i) => (
+        <span key={i} class="metrics-inline-item">
+          <MetricBullet variant={item.variant} text={item.text} />
+          {i < items.length - 1 && <span class="metrics-inline-sep">•</span>}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/webview-ui/src/components/molecules/MiniMapPanel.tsx
+++ b/webview-ui/src/components/molecules/MiniMapPanel.tsx
@@ -1,0 +1,13 @@
+interface MiniMapPanelProps {
+  title?: string
+  hasViewport?: boolean
+}
+
+export function MiniMapPanel({ title = 'Mini-map', hasViewport }: MiniMapPanelProps) {
+  return (
+    <div class="minimap-panel">
+      <div class="minimap-title">{title}</div>
+      {hasViewport && <div class="minimap-viewport" />}
+    </div>
+  )
+}

--- a/webview-ui/src/components/molecules/SearchBar.tsx
+++ b/webview-ui/src/components/molecules/SearchBar.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'preact/hooks'
+import { InputField } from '../atoms/InputField'
+import { KeyboardHintPill } from '../atoms/KeyboardHintPill'
+import { Icon } from '../atoms/Icon'
+
+interface SearchBarProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  trailingHint?: string
+  ariaLabel?: string
+}
+
+export function SearchBar({ value, onChange, placeholder, trailingHint, ariaLabel = 'search' }: SearchBarProps) {
+  const [internal, setInternal] = useState(value)
+
+  useEffect(() => {
+    const t = setTimeout(() => onChange(internal), 300)
+    return () => clearTimeout(t)
+  }, [internal])
+
+  return (
+    <InputField
+      value={internal}
+      placeholder={placeholder}
+      onChange={setInternal}
+      leadingIcon="search"
+      trailingSlot={
+        trailingHint ? (
+          <KeyboardHintPill label={trailingHint} />
+        ) : (
+          <Icon name="settings" size={20} colorToken="--text-secondary" />
+        )
+      }
+      ariaLabel={ariaLabel}
+    />
+  )
+}

--- a/webview-ui/src/components/molecules/SelectDropdown.tsx
+++ b/webview-ui/src/components/molecules/SelectDropdown.tsx
@@ -1,0 +1,61 @@
+import { Icon } from '../atoms/Icon'
+import type { ComponentChildren } from 'preact'
+import { useState } from 'preact/hooks'
+import { Tooltip } from '../atoms/Tooltip'
+
+interface Option { label: string; value: string }
+
+interface SelectDropdownProps {
+  label?: string
+  options: Option[]
+  value: string
+  onChange: (value: string) => void
+  helpTooltip?: ComponentChildren
+}
+
+export function SelectDropdown({ label, options, value, onChange, helpTooltip }: SelectDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const selected = options.find(o => o.value === value)
+  return (
+    <div class="select-dropdown" style={{ position: 'relative' }}>
+      {label && <label class="select-dropdown-label">{label}</label>}
+      <button
+        class="select-trigger"
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span>{selected?.label}</span>
+        <Icon name="chevron-down" size={16} colorToken="--text-secondary" />
+      </button>
+      {helpTooltip && (
+        <Tooltip content={helpTooltip}>
+          <span class="select-help">
+            <Icon name="help" size={16} colorToken="--text-secondary" />
+          </span>
+        </Tooltip>
+      )}
+      {open && (
+        <ul class="select-menu" role="listbox">
+          {options.map(opt => (
+            <li
+              key={opt.value}
+              class="select-option"
+              role="option"
+              aria-selected={opt.value === value}
+              onClick={() => {
+                onChange(opt.value)
+                setOpen(false)
+              }}
+            >
+              {opt.label}
+              {opt.value === value && (
+                <Icon name="check" size={16} colorToken="--accent-success" />
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/webview-ui/src/components/molecules/ZoomControlStack.tsx
+++ b/webview-ui/src/components/molecules/ZoomControlStack.tsx
@@ -1,0 +1,18 @@
+import { ButtonIcon } from '../atoms/ButtonIcon'
+
+interface ZoomControlStackProps {
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onFit: () => void
+  disabled?: boolean
+}
+
+export function ZoomControlStack({ onZoomIn, onZoomOut, onFit, disabled }: ZoomControlStackProps) {
+  return (
+    <div class="zoom-control-stack">
+      <ButtonIcon iconName="plus" onClick={onZoomIn} ariaLabel="Zoom in" disabled={disabled} />
+      <ButtonIcon iconName="minus" onClick={onZoomOut} ariaLabel="Zoom out" disabled={disabled} />
+      <ButtonIcon iconName="fullscreen" onClick={onFit} ariaLabel="Fit" disabled={disabled} />
+    </div>
+  )
+}

--- a/webview-ui/src/styles/global.css
+++ b/webview-ui/src/styles/global.css
@@ -47,6 +47,44 @@
   --kiro-node-jsx: #FFBD45;
   --kiro-node-json: #8DC891;
   --kiro-node-other: #B180D7;
+
+  /* Constellation design tokens */
+  --surface-canvas: var(--vscode-editor-background, #15131E);
+  --surface-card: var(--vscode-sideBar-background, #201A2C);
+  --surface-input: var(--vscode-input-background, #1D1926);
+  --surface-tint-brand: rgba(139, 92, 246, 0.18);
+  --surface-tint-success: rgba(34, 197, 94, 0.18);
+  --surface-overlay-04: rgba(255, 255, 255, 0.04);
+  --surface-overlay-08: rgba(255, 255, 255, 0.08);
+
+  --border-subtle: rgba(255, 255, 255, 0.10);
+  --border-strong: rgba(255, 255, 255, 0.18);
+  --border-focus: var(--vscode-focusBorder, #8B5CF6);
+
+  --text-primary: var(--vscode-foreground, #E8E6F3);
+  --text-secondary: var(
+    --vscode-descriptionForeground,
+    #B8B4C9
+  );
+  --text-muted: #8E8AA0;
+  --text-link: var(--vscode-textLink-foreground, #A78BFA);
+  --text-inverse: #0B0A10;
+
+  --accent-brand: var(--vscode-testing-iconQueued, #8B5CF6);
+  --accent-success: var(--vscode-testing-iconPassed, #22C55E);
+  --accent-purple-soft-text: #C7B7FF;
+  --accent-green-soft-text: #7EE28C;
+
+  --shadow-card: 0 0 0 1px rgba(255, 255, 255, 0.06), 0 8px 24px rgba(0, 0, 0, 0.35);
+  --shadow-float: 0 6px 18px rgba(0, 0, 0, 0.45);
+
+  --radius-chip: 9999px;
+  --radius-input: 12px;
+  --radius-card: 16px;
+  --radius-tile: 12px;
+
+  --ease-ui: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --duration-fast: 160ms;
 }
 
 html, body, #root {
@@ -72,6 +110,360 @@ body {
   border: 1px solid var(--vscode-button-border, transparent);
   border-radius: var(--kiro-radius-1);
   cursor: pointer;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+  transition: background var(--duration-fast) var(--ease-ui);
+}
+.chip:hover {
+  box-shadow: 0 0 0 1000px var(--surface-overlay-04) inset;
+}
+.chip:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+.button-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-tile);
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-float);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-ui);
+}
+.button-icon:hover:not(:disabled) {
+  box-shadow: var(--shadow-float);
+  background: var(--surface-overlay-04);
+}
+.button-icon:active {
+  background: var(--surface-overlay-08);
+}
+.button-icon:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+.button-icon:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.button-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-link);
+  cursor: pointer;
+  text-decoration: none;
+  font-size: inherit;
+}
+.button-link:hover {
+  text-decoration: underline;
+}
+.button-link:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+.button-link[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.input-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 42px;
+  padding: 0 12px;
+  background: var(--surface-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-input);
+}
+.input-field:hover {
+  box-shadow: 0 0 0 1000px var(--surface-overlay-04) inset;
+}
+.input-field:focus-within {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+.input-field-input {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 14px;
+}
+.input-field-input::placeholder {
+  color: #9B97AC;
+}
+.input-field-input:focus {
+  outline: none;
+}
+
+.kbd-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 24px;
+  padding: 0 8px;
+  border-radius: var(--radius-chip);
+  background: rgba(255, 255, 255, 0.06);
+  color: #CFCDE1;
+  font-size: 12px;
+}
+
+.metric-bullet {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.metric-bullet-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.metric-bullet-text {
+  color: var(--text-secondary);
+}
+
+.tooltip {
+  position: absolute;
+  padding: 6px 8px;
+  background: var(--surface-card);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  color: var(--text-primary);
+  font-size: 12px;
+  z-index: 100;
+}
+.tooltip-top {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-4px);
+}
+.tooltip-bottom {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+}
+
+/* SelectDropdown */
+.select-dropdown {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 40px;
+  padding: 0 12px;
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-input);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.select-trigger:hover {
+  box-shadow: 0 0 0 1000px var(--surface-overlay-04) inset;
+}
+.select-trigger:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+.select-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-input);
+  margin-top: 4px;
+  list-style: none;
+  padding: 4px 0;
+  box-shadow: var(--shadow-card);
+  z-index: 10;
+}
+.select-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+  height: 36px;
+  cursor: pointer;
+}
+.select-option:hover {
+  background: var(--surface-overlay-04);
+}
+.select-help {
+  display: inline-flex;
+}
+
+/* ActionCard */
+.action-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  padding: 16px;
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-ui);
+}
+.action-card:hover {
+  box-shadow: var(--shadow-card);
+  background: var(--surface-overlay-04);
+}
+.action-card:active {
+  background: var(--surface-overlay-08);
+}
+.action-card:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+.action-card:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.action-card-text {
+  flex: 1;
+  text-align: left;
+}
+.action-card-title {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+.action-card-subtitle {
+  color: var(--text-secondary);
+  font-size: 12px;
+  margin-top: 4px;
+}
+.action-card-right {
+  margin-left: auto;
+}
+
+/* DataStatusCard */
+.data-status-card {
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+}
+.data-status-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.data-status-title {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+.data-status-subline {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+.data-status-stats {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+.stat-sep {
+  margin: 0 4px;
+  color: var(--text-secondary);
+}
+
+/* MetricsInline */
+.metrics-inline {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.metrics-inline-item {
+  display: flex;
+  align-items: center;
+}
+.metrics-inline-sep {
+  margin: 0 4px;
+  color: var(--text-muted);
+}
+
+/* ChipGroup */
+.chip-group {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* ZoomControlStack */
+.zoom-control-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* MiniMapPanel */
+.minimap-panel {
+  background: var(--surface-card);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-card);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.minimap-title {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+.minimap-viewport {
+  border: 2px solid var(--border-strong);
+  background: var(--surface-overlay-04);
+  flex: 1;
+}
+
+/* BreadcrumbItem */
+.breadcrumb-item {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+.breadcrumb-item:hover {
+  text-decoration: underline;
+}
+.breadcrumb-item:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
 }
 
 /* New button system (variants layered on top of existing .button for back-compat) */

--- a/webview-ui/src/views/Playground.tsx
+++ b/webview-ui/src/views/Playground.tsx
@@ -1,0 +1,74 @@
+import { Icon } from '../components/atoms/Icon'
+import { IconTile } from '../components/atoms/IconTile'
+import { StatusDot } from '../components/atoms/StatusDot'
+import { Chip } from '../components/atoms/Chip'
+import { ButtonIcon } from '../components/atoms/ButtonIcon'
+import { ButtonLink } from '../components/atoms/ButtonLink'
+import { InputField } from '../components/atoms/InputField'
+import { KeyboardHintPill } from '../components/atoms/KeyboardHintPill'
+import { MetricBullet } from '../components/atoms/MetricBullet'
+import { Tooltip } from '../components/atoms/Tooltip'
+import { DividerLine } from '../components/atoms/DividerLine'
+import { SearchBar } from '../components/molecules/SearchBar'
+import { ActionCard } from '../components/molecules/ActionCard'
+import { DataStatusCard } from '../components/molecules/DataStatusCard'
+import { MetricsInline } from '../components/molecules/MetricsInline'
+import { ChipGroup } from '../components/molecules/ChipGroup'
+import { ZoomControlStack } from '../components/molecules/ZoomControlStack'
+import { MiniMapPanel } from '../components/molecules/MiniMapPanel'
+import { BreadcrumbItem } from '../components/molecules/BreadcrumbItem'
+import { SelectDropdown } from '../components/molecules/SelectDropdown'
+import { useState } from 'preact/hooks'
+
+export function Playground() {
+  const [search, setSearch] = useState('')
+  const [mode, setMode] = useState('one')
+  return (
+    <div style={{ padding: '20px', display: 'flex', flexDirection: 'column', gap: '16px', color: 'var(--text-primary)' }}>
+      <h2>Atoms</h2>
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <Icon name="search" />
+        <IconTile variant="brand" iconName="plus" />
+        <StatusDot status="healthy" size={8} />
+        <Chip label="JavaScript" variant="brand" />
+        <ButtonIcon iconName="plus" ariaLabel="Add" onClick={() => {}} />
+        <ButtonLink onClick={() => {}}>Re-index Now</ButtonLink>
+        <InputField value="" onChange={() => {}} ariaLabel="example" placeholder="Input" />
+        <KeyboardHintPill label="⌘K" />
+        <MetricBullet variant="green" text="42" />
+        <Tooltip content="Hello"><span>Hover me</span></Tooltip>
+        <DividerLine />
+      </div>
+
+      <h2>Molecules</h2>
+      <SearchBar value={search} onChange={setSearch} placeholder="Search" trailingHint="⌘K" />
+      <SelectDropdown
+        options={[{ label: 'One', value: 'one' }, { label: 'Two', value: 'two' }]}
+        value={mode}
+        onChange={setMode}
+        helpTooltip="Choose mode"
+      />
+      <ActionCard title="Title" subtitle="Subtitle" variant="brand" iconName="plus" />
+      <DataStatusCard
+        title="Repo data"
+        lastIndexedText="Indexed today"
+        filesCount={10}
+        depsCount={5}
+        status="healthy"
+        onReindex={() => {}}
+      />
+      <MetricsInline items={[{ variant: 'purple', text: '10 files' }, { variant: 'green', text: 'Real-time' }]} />
+      <ChipGroup
+        chips={[{ label: 'JS', variant: 'brand' }, { label: 'TS', variant: 'success' }]}
+        selectMode="multi"
+      />
+      <ZoomControlStack onZoomIn={() => {}} onZoomOut={() => {}} onFit={() => {}} />
+      <MiniMapPanel hasViewport />
+      <div style={{ display: 'flex', gap: '4px' }}>
+        <BreadcrumbItem label="root" onClick={() => {}} />
+        <BreadcrumbItem label="src" onClick={() => {}} />
+        <BreadcrumbItem label="index.ts" active onClick={() => {}} />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add VS Code token-based theme variables in `global.css`
- build reusable atom components (Icon, Chip, ButtonIcon, InputField, etc.)
- compose molecules like SearchBar, SelectDropdown, ActionCard and more with demo Playground view

## Testing
- `npm run build:ui`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c744cd75cc8333870e707e5c69bddd