### PR TITLE
Feature/performance enhance graph

### DIFF
--- a/filter-chip-prd.md
+++ b/filter-chip-prd.md
@@ -1,0 +1,198 @@
+# Graph Filter Chips — PRD (Phase 1)
+
+Owner: Constellation UI
+Status: Draft
+Scope: Enable file-type filter chips in the Graph view (webview UI) with correct interaction across normal, focus, and impact modes.
+
+## Background
+The graph currently renders file nodes colored by file type (ts, tsx, js, jsx, json, other). The toolbar UI shows non-functional “Filters” chips (disabled). This PRD defines how to implement working filter chips that let users quickly filter nodes by file type without re-running the scan. The feature must integrate with Focus Mode, Impact View, Search, and remain performant.
+
+## Goals
+- Allow toggling file-type chips (TS/TSX/JS/JSX/JSON/Other) to filter visible nodes.
+- Intersect filter visibility with Focus Mode visibility (if active) and Impact subgraph (if active).
+- Hide edges whose endpoints are not both visible after filtering.
+- Update counts next to chips based on the active graph (Focus/Impact aware) to provide immediate feedback.
+- Persist chip selection during the session; optional workspace persistence.
+
+## Non-Goals
+- Persisting filter selections across VS Code reloads (optional stretch).
+- Arbitrary custom filters (by directory, degree, authors, etc.).
+- Server-side filtering or changes to dependency-cruiser output.
+
+## User Stories
+1) As a user, I can toggle a TS chip to only see TypeScript files in the graph.
+2) As a user in Focus Mode, chip filters reduce visible nodes to only those matching both the focus visibility and enabled chips.
+3) As a user in Impact View, chip filters apply within the impact subgraph.
+4) As a user, Search respects current filters (centers on the first matching visible node); if no matches due to filters, I’m informed.
+5) As a user, I can clear filters quickly to return to the full graph (within the current mode).
+
+## UX
+- Location: Graph toolbar row 2, left of the stats.
+- Chips: TS, TSX, JS, JSX, JSON, Other.
+- States: selected (default), unselected, disabled (0 available in current active graph).
+- Counts: optional small number on/next to chip label (e.g., TS (24)). Counts reflect the current active graph (impact subgraph if active; otherwise full graph). In Focus Mode, counts reflect nodes in the currently focused visible set.
+- Clear: “Clear filters” link appears when not all types are selected.
+- Accessibility: chips are buttons with aria-pressed; keyboard navigable.
+
+## Functional Requirements
+- R1: Toggling chips immediately updates visibility.
+- R2: Visibility set = intersection of:
+  - Full graph nodes (or impact filtered nodes),
+  - Focus Mode visible set (if active),
+  - Enabled chip file types set.
+- R3: Edges are visible only if both endpoints remain visible.
+- R4: Search: scopes to the current active visibility; if no results, show a brief toast or banner.
+- R5: Reset behaviors:
+  - Graph “Reset View” (impact banner equivalent or the menu) leaves chips unchanged, but recalculates counts.
+  - “Clear filters” returns all chips to selected.
+- R6: Session persistence: store filter selection in memory; optional: workspace storage key.
+
+## Data Model
+- File type derivation:
+  - Already computed in GraphCanvas (data.ext) via getFileExt(path), and in styles via graph-styles.service.
+  - For accuracy inside GraphDashboard, derive ext from node.path or add ext to GraphData nodes once during transformation.
+- New UI state in GraphDashboard:
+  - filterState: {
+    enabledExts: Set<'ts'|'tsx'|'js'|'jsx'|'json'|'other'>,
+    counts: Record<FileType, number>
+  }
+- Default: enabledExts = all present types.
+
+## Interaction Model (Modes)
+- Normal: visible = nodes whose ext in enabledExts.
+- Impact: visible = nodes in impact subgraph with ext in enabledExts.
+- Focus + (Normal|Impact):
+  - baseVisible = Focus visible set
+  - filteredVisible = baseVisible ∩ enabledExts
+  - recompute edges by endpoints in filteredVisible
+
+## Performance
+- Updates occur in the webview; sets are typically O(N) over nodes (N ~ 100–2000). OK.
+- Use batch operations on Cytoscape in GraphCanvas.applyFocusView to avoid flicker.
+
+## Accessibility
+- Chips must be buttons with aria-pressed and focus outlines.
+- Labels use human-readable names (TypeScript, JavaScript, etc.).
+
+## Telemetry (optional)
+- Number of toggles per session and common combinations (e.g., TS only).
+
+## Failure Handling
+- If the user selects no chips, show an inline hint “No types selected — click Clear filters” and hide everything.
+
+## QA Matrix
+- Graph only: toggle TS/JS quickly; edges hide/show correctly.
+- Impact + chips: apply chips and verify nodes limited to intersection.
+- Focus + chips: drill into a node, then toggle JS off; verify intersection.
+- Search + chips: search for a node that only matches when a chip is enabled.
+- Large graphs (1000+ nodes): observe responsiveness.
+- Reset/clear flows: Reset View and Clear filters behave as expected.
+
+## Implementation Plan (file-by-file)
+
+### 1) webview-ui/src/components/GraphToolbar.tsx
+- Props:
+  - onToggleFilter(ext: FileType): void
+  - onClearFilters(): void
+  - filterState: { enabledExts: Set<FileType>; counts: Record<FileType, number> }
+- Render chips for file types in getSupportedFileTypes().
+- Determine disabled = counts[ext] === 0.
+- Visual state = selected if enabledExts.has(ext).
+- Implement Clear filters ButtonLink only when not all enabled.
+
+### 2) webview-ui/src/components/GraphDashboard.tsx
+- State:
+  - filterState: as defined above.
+- Helpers:
+  - deriveExt(node: { path: string }): FileType (use file-type.service or path ext mapping)
+  - computeAvailableCounts(activeGraph: GraphData, focusVisible?: Set<string>): counts
+  - getActiveGraph(): GraphData => (impactState.filteredGraph || fullGraphData)
+- Event wiring:
+  - On graph/data, impact changes, or focus changes: recompute counts.
+  - onToggleFilter(ext): toggle in enabledExts; recompute visibility.
+  - onClearFilters(): set enabledExts = all present; recompute.
+- Visibility application pipeline (single place):
+  - baseGraph = getActiveGraph()
+  - baseVisibleNodes = (focusState.isActive ? focusState.visibleNodes : Set(all node ids))
+  - filteredVisibleNodes = new Set([...baseVisibleNodes].filter(id => extOf(id) in enabledExts))
+  - filteredVisibleEdges = recompute via endpoints ∈ filteredVisibleNodes
+  - Call applyFocusView({ visibleNodes: filteredVisibleNodes, visibleEdges: filteredVisibleEdges, rootId: (focusState.root ?? null) })
+  - If no focus active, rootId can be null; applyFocusView will only hide/show.
+- Search integration:
+  - Current onSearch already selects first matching node from the active graph. Adapt to prefer a node within the current filteredVisibleNodes. If none, show toast “No results in current filters”.
+
+### 3) webview-ui/src/components/GraphCanvas.tsx
+- No major changes; reuse applyFocusView.
+- Optional: add a convenience method applyVisibilityMask({ visibleNodes: Set<string> }) which internally computes edge visibility by endpoints. Not required since Dashboard already aligns edges.
+
+### 4) webview-ui/src/services/graph-styles.service.ts
+- No functional changes; already provides getSupportedFileTypes and mapping. Consider exposing getFileTypeLabel for chip labels.
+
+### 5) webview-ui/src/services/file-type.service.ts
+- Ensure we can resolve ext for any file path; export type FileType = 'ts'|'tsx'|'js'|'jsx'|'json'|'other'.
+
+### 6) Styling (webview-ui/src/styles/global.css)
+- Chip styles: selected vs unselected (class name modifier or aria-pressed [true|false]).
+- Counts appearance (small badge).
+- “Clear filters” ButtonLink placement and spacing.
+
+### 7) Persistence (optional)
+- Use window.localStorage or VS Code’s webview state (acquireVsCodeApi().setState()) to persist enabledExts per session.
+- Future: workspaceStorage key via webview <-> extension message (not required in Phase 1).
+
+## Edge Cases & Interactions
+- All chips off: hide everything; show a hint.
+- Focus root filtered out: keep root visible regardless? Decision: respect filters strictly (root can disappear). Provide inline hint: “Focus root is hidden by filters”. (Alternative: always keep root visible; trade-off: inconsistent filtering.)
+- Counts in Focus Mode: counts reflect baseVisibleNodes before filtering to help users understand what’s available.
+
+## Risks
+- Confusion if Focus root becomes hidden: mitigate by hinting. (Decision required; see above.)
+- Performance: repeated set operations on large graphs; mitigation: memoize ext lookup per id.
+- Interaction order: Apply filter after focus computation; ensure deferred-apply (needsFocusApplyRef) covers race conditions.
+
+## Open Questions
+1) Should Focus root be exempt from filters? (Proposed: no exemption.)
+2) Persist filters across sessions? If yes, where? (Phase 2)
+3) Show TS/JS by default in toolbar (compact) or all types? (Phase 1: all types as chips; legend remains TS/JS only.)
+
+## Acceptance Criteria
+- Toggling any chip hides/shows nodes immediately without re-scan.
+- In Impact View, chips filter within the impact subgraph.
+- In Focus Mode, chips filter the focused visible set (intersection logic verified).
+- Search centers on a node that matches query within current filters; if none, shows toast.
+- Clear filters returns to “all chips enabled”.
+- No console errors; frame remains responsive on 1000+ node graphs.
+
+## Rollout Plan
+- Phase 1: TS/TSX/JS/JSX/JSON/Other chips; no persistence across sessions.
+- Phase 2 (optional): persist filters; add keyboard shortcuts (e.g., Alt+1..6 to toggle chips).
+- Phase 3 (optional): advanced filters (by directory, deg, git activity).
+
+## Timeline (estimates)
+- Wiring UI + state (Toolbar + Dashboard): 0.5–1 day
+- Canvas intersection + QA (Normal/Impact/Focus/Search): 0.5–1 day
+- Polish + a11y + docs: 0.5 day
+
+## File Change Checklist
+- [ ] webview-ui/src/components/GraphToolbar.tsx
+  - [ ] Props: onToggleFilter, onClearFilters, filterState
+  - [ ] Interactive chips with counts and ARIA
+- [ ] webview-ui/src/components/GraphDashboard.tsx
+  - [ ] filterState + helpers + counts
+  - [ ] apply visibility intersection pipeline
+  - [ ] search respects filters
+- [ ] webview-ui/src/components/GraphCanvas.tsx
+  - [ ] (Optional) helper for visibility mask
+- [ ] webview-ui/src/services/file-type.service.ts
+  - [ ] Ensure file type derivation and export FileType
+- [ ] webview-ui/src/services/graph-styles.service.ts
+  - [ ] getFileTypeLabel/export (already present)
+- [ ] webview-ui/src/styles/global.css
+  - [ ] Chip styles, counts, layout
+- [ ] Docs: add a short section in docs/ui-components.md for filter chips
+
+## Dev Notes
+- Keep GraphDashboard as the single source of truth for visibility. Call GraphCanvas.applyFocusView once per change, passing the final visible nodes/edges sets.
+- Maintain an id→ext map memo in GraphDashboard to avoid recomputing extensions.
+- Keep the legend (TS/JS) minimal and independent from the filter chips.
+

--- a/webview-ui/src/components/FileInfoPanel.tsx
+++ b/webview-ui/src/components/FileInfoPanel.tsx
@@ -35,7 +35,13 @@ function formatRelative(ts: number | null): string {
 
 export function FileInfoPanel({ nodeId, node, inDegree, outDegree, metrics, metricsReady, onOpenFile, onClose }: NodeInfoPanelProps) {
   const title = node?.label || nodeId.split('/').slice(-1)[0]
-  const pathText = node?.id || nodeId
+  const rawId = node?.id || nodeId
+  const isAbsolute = rawId.startsWith('/') || /^[A-Za-z]:[\\\/]/.test(rawId)
+  const looksOutside = rawId.startsWith('..')
+  const displayPath = (!isAbsolute && !looksOutside)
+    ? rawId
+    : (node?.label || rawId.split(/[\\\/]/).slice(-1)[0] || rawId)
+  const tooltipPath = node?.path || rawId
 
   const metricItems = useMemo(() => {
     if (!metricsReady) return 'loading'
@@ -48,7 +54,7 @@ export function FileInfoPanel({ nodeId, node, inDegree, outDegree, metrics, metr
       <div className="file-info-header">
         <div className="file-info-titles">
           <div className="file-info-title">{title}</div>
-          <div className="file-info-path" title={pathText}>{pathText}</div>
+          <div className="file-info-path" title={tooltipPath}>{displayPath}{(isAbsolute || looksOutside) && '  (outside workspace)'}</div>
         </div>
         <span className="file-info-close">
 <ButtonIcon iconName="close" ariaLabel="Close" onClick={onClose} size={28} />

--- a/webview-ui/src/components/FocusBreadcrumb.tsx
+++ b/webview-ui/src/components/FocusBreadcrumb.tsx
@@ -28,7 +28,7 @@ export function FocusBreadcrumb({ crumbs, onJump, onReset, onDepthChange, curren
               label={crumb.label}
               onClick={() => onJump(index)}
               title={crumb.root}
-              type="button"
+           
             />
             {index < crumbs.length - 1 && (
               <span class="focus-crumb-sep" aria-hidden="true">▶</span>
@@ -51,7 +51,7 @@ export function FocusBreadcrumb({ crumbs, onJump, onReset, onDepthChange, curren
           <ButtonLink 
             class="focus-reset" 
             onClick={onImpactReset}
-            type="button"
+         
             title="Reset Impact View"
           >
             Reset Impact
@@ -60,7 +60,7 @@ export function FocusBreadcrumb({ crumbs, onJump, onReset, onDepthChange, curren
         <ButtonLink 
           class="focus-reset" 
           onClick={onReset}
-          type="button"
+         
           title="Reset Focus"
         >
           Reset

--- a/webview-ui/src/components/FocusBreadcrumb.tsx
+++ b/webview-ui/src/components/FocusBreadcrumb.tsx
@@ -10,9 +10,11 @@ export interface FocusBreadcrumbProps {
   onReset: () => void;
   onDepthChange?: (delta: 1 | -1) => void;
   currentDepth?: number; // 0 = All
+  impactLabel?: string;
+  onImpactReset?: () => void;
 }
 
-export function FocusBreadcrumb({ crumbs, onJump, onReset, onDepthChange, currentDepth }: FocusBreadcrumbProps) {
+export function FocusBreadcrumb({ crumbs, onJump, onReset, onDepthChange, currentDepth, impactLabel, onImpactReset }: FocusBreadcrumbProps) {
   if (crumbs.length === 0) {
     return null;
   }
@@ -35,6 +37,9 @@ export function FocusBreadcrumb({ crumbs, onJump, onReset, onDepthChange, curren
         ))}
       </div>
       <div style="display:flex; align-items:center; gap:8px;">
+        {impactLabel && (
+          <div class="chip chip--brand" title={`Impact source: ${impactLabel}`}>Impact: {impactLabel}</div>
+        )}
         {onDepthChange && (
           <div class="focus-depth-controls" style="display:flex;align-items:center;gap:6px;">
             <span class="toolbar-label">Depth: {currentDepth === 0 || currentDepth === undefined ? 'All' : String(currentDepth)}</span>
@@ -42,10 +47,21 @@ export function FocusBreadcrumb({ crumbs, onJump, onReset, onDepthChange, curren
             <ButtonIcon class="btn-sm" iconName="plus" ariaLabel="Increase depth" onClick={() => onDepthChange(1)} />
           </div>
         )}
+        {onImpactReset && (
+          <ButtonLink 
+            class="focus-reset" 
+            onClick={onImpactReset}
+            type="button"
+            title="Reset Impact View"
+          >
+            Reset Impact
+          </ButtonLink>
+        )}
         <ButtonLink 
           class="focus-reset" 
           onClick={onReset}
           type="button"
+          title="Reset Focus"
         >
           Reset
         </ButtonLink>

--- a/webview-ui/src/components/GraphDashboard.tsx
+++ b/webview-ui/src/components/GraphDashboard.tsx
@@ -753,6 +753,8 @@ export function GraphDashboard() {
             onJump={handleBreadcrumbJump}
             onReset={handleReset}
             currentDepth={focusState.depth === Number.MAX_SAFE_INTEGER ? 0 : focusState.depth}
+            impactLabel={impactState.isActive ? (focusState.crumbs[0]?.label ?? impactState.data?.sourceFile) : undefined}
+            onImpactReset={impactState.isActive ? handleResetImpactView : undefined}
             onDepthChange={(delta) => {
               // Implement true +/- depth control with clamping
               const last = focusState.crumbs[focusState.crumbs.length - 1]
@@ -827,13 +829,7 @@ export function GraphDashboard() {
           </div>
         )}
 
-        {/* Impact banner */}
-        {impactState.isActive && (
-          <div className="banner-impact" role="status" aria-live="polite">
-            <span className="banner-text">Impact View — source: {impactState.data?.sourceFile}</span>
-            <Button class="btn-secondary btn-sm" onClick={handleResetImpactView} data-testid="graph-reset-banner-button">↺ Reset View</Button>
-          </div>
-        )}
+        {/* Impact banner consolidated into breadcrumbs chip; no separate banner */}
 
         {/* Loading State */}
         {state.type === 'loading' && (

--- a/webview-ui/src/components/GraphDashboard.tsx
+++ b/webview-ui/src/components/GraphDashboard.tsx
@@ -121,6 +121,8 @@ export function GraphDashboard() {
   const forwardAdjRef = useRef<Map<string, string[]>>(new Map())
   const reverseAdjRef = useRef<Map<string, string[]>>(new Map())
   const graphCanvasRef = useRef<GraphCanvasRef>(null)
+  // Flag to apply focus after rendering/layout completes
+  const needsFocusApplyRef = useRef<boolean>(false)
 
   // Helper function to rebuild adjacency maps for the active graph
   const rebuildAdjacencyMaps = useCallback((activeGraph: GraphData) => {
@@ -161,6 +163,29 @@ export function GraphDashboard() {
       }
     }
   }, [])
+
+  // Align visible edge IDs with actual graph edge IDs (handles '-1' suffix collisions)
+  const getAlignedVisibleEdges = useCallback((activeGraph: GraphData, visibleNodes: Set<string>): Set<string> => {
+    const aligned = new Set<string>()
+    for (const e of activeGraph.edges) {
+      if (visibleNodes.has(e.source) && visibleNodes.has(e.target)) {
+        aligned.add(e.id)
+      }
+    }
+    return aligned
+  }, [])
+
+  // Helper to apply the current focus to the canvas and center on root
+  const applyFocus = useCallback((activeGraph: GraphData, visibleNodes: Set<string>, rootId: string) => {
+    if (!graphCanvasRef.current) return
+    const alignedEdges = getAlignedVisibleEdges(activeGraph, visibleNodes)
+    graphCanvasRef.current.applyFocusView({
+      visibleNodes,
+      visibleEdges: alignedEdges,
+      rootId
+    })
+    graphCanvasRef.current.centerOn(rootId, { animate: true })
+  }, [getAlignedVisibleEdges])
 
   // Function to reset impact view and restore full graph
   const handleResetImpactView = useCallback(() => {
@@ -284,12 +309,9 @@ export function GraphDashboard() {
 
       // Apply focus view showing only the root node
       if (graphCanvasRef.current) {
-        graphCanvasRef.current.applyFocusView({
-          visibleNodes: new Set([nodeId]),
-          visibleEdges: new Set(),
-          rootId: nodeId
-        })
-        graphCanvasRef.current.centerOn(nodeId, { animate: true })
+        applyFocus(activeGraph, new Set([nodeId]), nodeId)
+      } else {
+        needsFocusApplyRef.current = true
       }
       return
     }
@@ -336,13 +358,10 @@ export function GraphDashboard() {
       }))
 
       // Apply focus view to canvas
-      if (graphCanvasRef.current) {
-        graphCanvasRef.current.applyFocusView({
-          visibleNodes: visibilityResult.visibleNodes,
-          visibleEdges: visibilityResult.visibleEdges,
-          rootId: nodeId
-        })
-        graphCanvasRef.current.centerOn(nodeId, { animate: true })
+      if (graphCanvasRef.current && !isRendering) {
+        applyFocus(activeGraph, visibilityResult.visibleNodes, nodeId)
+      } else {
+        needsFocusApplyRef.current = true
       }
 
       // Log extreme fan-out warning
@@ -419,13 +438,10 @@ export function GraphDashboard() {
       }))
 
       // Apply focus view to canvas
-      if (graphCanvasRef.current) {
-        graphCanvasRef.current.applyFocusView({
-          visibleNodes: visibilityResult.visibleNodes,
-          visibleEdges: visibilityResult.visibleEdges,
-          rootId: targetCrumb.root
-        })
-        graphCanvasRef.current.centerOn(targetCrumb.root, { animate: true })
+      if (graphCanvasRef.current && !isRendering) {
+        applyFocus(activeGraph, visibilityResult.visibleNodes, targetCrumb.root)
+      } else {
+        needsFocusApplyRef.current = true
       }
 
     } catch (error) {
@@ -481,6 +497,44 @@ export function GraphDashboard() {
               
               setImpactState((prev) => ({ ...prev, filteredGraph }))
               setState({ type: 'data', data: filteredGraph })
+
+              // Compute and apply initial focus for deferred impact
+              const sourceId = impactRef.current.data.sourceFile
+              if (filteredGraph.nodes.some(n => n.id === sourceId)) {
+                const visibilityResult = computeVisible({
+                  forwardAdj: forwardAdjRef.current,
+                  reverseAdj: reverseAdjRef.current,
+                  root: sourceId,
+                  depth: Number.MAX_SAFE_INTEGER,
+                  lens: 'children',
+                  maxChildren: 100
+                })
+
+                const childrenCount = countChildren(forwardAdjRef.current, reverseAdjRef.current, sourceId, 'children')
+                const maxChildren = 100
+                const hasMore = childrenCount > maxChildren
+                const displayCount = Math.min(childrenCount, maxChildren)
+
+                setFocusState({
+                  isActive: true,
+                  root: sourceId,
+                  depth: Number.MAX_SAFE_INTEGER,
+                  lens: 'children',
+                  visibleNodes: visibilityResult.visibleNodes,
+                  visibleEdges: visibilityResult.visibleEdges,
+                  crumbs: [formatCrumb(filteredGraph, sourceId, Number.MAX_SAFE_INTEGER, 'children')],
+                  positionCache: {},
+                  error: null,
+                  childrenInfo: { count: childrenCount, hasMore, displayCount }
+                })
+
+                // Try to apply immediately; otherwise defer until render completes
+                if (graphCanvasRef.current && !isRendering) {
+                  applyFocus(filteredGraph, visibilityResult.visibleNodes, sourceId)
+                } else {
+                  needsFocusApplyRef.current = true
+                }
+              }
             } catch (error) {
               console.error('Failed to compute filtered graph or build adjacency maps:', error)
               // Fallback to full graph
@@ -576,6 +630,13 @@ export function GraphDashboard() {
                     displayCount
                   }
                 })
+
+                // Try to apply immediately; otherwise defer until render completes
+                if (graphCanvasRef.current && !isRendering) {
+                  applyFocus(filteredGraph, visibilityResult.visibleNodes, impactData.sourceFile)
+                } else {
+                  needsFocusApplyRef.current = true
+                }
               } catch (error) {
                 console.error('Failed to compute focus view for impact source:', error)
                 // Fall back to showing the filtered graph without focus
@@ -643,6 +704,23 @@ export function GraphDashboard() {
 
     return () => clearInterval(cleanupInterval)
   }, [fullGraphData, focusState.positionCache])
+
+  // Apply deferred focus once rendering/layout completes
+  useEffect(() => {
+    if (state.type !== 'data') return
+    if (isRendering) return
+    if (!focusState.isActive || !focusState.root) return
+    if (!needsFocusApplyRef.current) return
+
+    const activeGraph = impactState.isActive && impactState.filteredGraph
+      ? impactState.filteredGraph
+      : fullGraphData
+
+    if (activeGraph) {
+      applyFocus(activeGraph, focusState.visibleNodes, focusState.root)
+      needsFocusApplyRef.current = false
+    }
+  }, [state.type, isRendering, focusState.isActive, focusState.root, impactState.isActive, fullGraphData, applyFocus])
 
   const handleRescan = useCallback(() => {
     // Reset rendering state when starting a new scan

--- a/webview-ui/src/components/molecules/MiniMapPanel.tsx
+++ b/webview-ui/src/components/molecules/MiniMapPanel.tsx
@@ -13,18 +13,28 @@ export function MiniMapPanel({ title = 'Mini-map', bounds, viewport, ...rest }: 
   const props = { ...rest } as any
   delete props.class
 
-  // Calculate viewport rectangle relative to bounds and viewport container size (CSS fixed height)
+  // Calculate viewport rectangle relative to a world rect that covers both graph bounds and current viewport
   let rectStyle: JSX.CSSProperties | undefined
-  if (bounds && viewport && bounds.w > 0 && bounds.h > 0) {
+  if (bounds && viewport) {
+    // Build a world rectangle that is the union of bounds and viewport extents
+    const worldX1 = Math.min(bounds.x1, viewport.x1)
+    const worldY1 = Math.min(bounds.y1, viewport.y1)
+    const worldX2 = Math.max(bounds.x2, viewport.x2)
+    const worldY2 = Math.max(bounds.y2, viewport.y2)
+    const worldW = Math.max(1, worldX2 - worldX1)
+    const worldH = Math.max(1, worldY2 - worldY1)
+
     const pad = 8 // inner padding of container if any (approx)
     const containerWidth = 220 - pad * 2
     const containerHeight = 120 - pad * 2
-    const scaleX = containerWidth / bounds.w
-    const scaleY = containerHeight / bounds.h
-    const left = Math.max(0, (viewport.x1 - bounds.x1) * scaleX)
-    const top = Math.max(0, (viewport.y1 - bounds.y1) * scaleY)
+    const scaleX = containerWidth / worldW
+    const scaleY = containerHeight / worldH
+
+    const left = (viewport.x1 - worldX1) * scaleX
+    const top = (viewport.y1 - worldY1) * scaleY
     const width = Math.max(6, viewport.w * scaleX)
     const height = Math.max(6, viewport.h * scaleY)
+
     rectStyle = { left: `${left}px`, top: `${top}px`, width: `${width}px`, height: `${height}px` }
   }
 

--- a/webview-ui/src/components/molecules/MiniMapPanel.tsx
+++ b/webview-ui/src/components/molecules/MiniMapPanel.tsx
@@ -2,48 +2,33 @@ import { JSX } from 'preact'
 
 interface Bounds { x1: number; y1: number; x2: number; y2: number; w: number; h: number }
 
+import { getSupportedFileTypes, getFileTypeColor, getFileTypeLabel } from '../../services/graph-styles.service'
+
 interface MiniMapPanelProps extends JSX.HTMLAttributes<HTMLDivElement> {
   title?: string
   bounds?: Bounds | null
   viewport?: Bounds | null
 }
 
-export function MiniMapPanel({ title = 'Mini-map', bounds, viewport, ...rest }: MiniMapPanelProps) {
+export function MiniMapPanel({ title = 'Legend', ...rest }: MiniMapPanelProps) {
   const className = ['mini-map', (rest as any).class ?? ''].filter(Boolean).join(' ')
   const props = { ...rest } as any
   delete props.class
 
-  // Calculate viewport rectangle relative to a world rect that covers both graph bounds and current viewport
-  let rectStyle: JSX.CSSProperties | undefined
-  if (bounds && viewport) {
-    // Build a world rectangle that is the union of bounds and viewport extents
-    const worldX1 = Math.min(bounds.x1, viewport.x1)
-    const worldY1 = Math.min(bounds.y1, viewport.y1)
-    const worldX2 = Math.max(bounds.x2, viewport.x2)
-    const worldY2 = Math.max(bounds.y2, viewport.y2)
-    const worldW = Math.max(1, worldX2 - worldX1)
-    const worldH = Math.max(1, worldY2 - worldY1)
-
-    const pad = 8 // inner padding of container if any (approx)
-    const containerWidth = 220 - pad * 2
-    const containerHeight = 120 - pad * 2
-    const scaleX = containerWidth / worldW
-    const scaleY = containerHeight / worldH
-
-    const left = (viewport.x1 - worldX1) * scaleX
-    const top = (viewport.y1 - worldY1) * scaleY
-    const width = Math.max(6, viewport.w * scaleX)
-    const height = Math.max(6, viewport.h * scaleY)
-
-    rectStyle = { left: `${left}px`, top: `${top}px`, width: `${width}px`, height: `${height}px` }
-  }
+  // Show all file types in the legend
+  const fileTypes = getSupportedFileTypes()
 
   return (
     <div class={className} {...props}>
       <div class="mini-map-title">{title}</div>
-      <div class="mini-map-viewport">
-        {rectStyle && <div class="mini-map-rect" style={rectStyle} />}
-      </div>
+      <ul class="legend-list legend-grid-2">
+        {fileTypes.map((ft) => (
+          <li class="legend-item legend-item-sm" key={ft}>
+            <span class="legend-swatch legend-swatch-sm" style={{ backgroundColor: getFileTypeColor(ft) }} />
+            <span class="legend-label legend-label-sm">{ft.toUpperCase()}</span>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/webview-ui/src/styles/global.css
+++ b/webview-ui/src/styles/global.css
@@ -421,12 +421,18 @@ body {
 /* ZoomControlStack */
 .zoom-stack { position:absolute; right:12px; bottom:12px; display:flex; flex-direction:column; gap:8px; }
 
-/* MiniMapPanel */
-.graph-minimap-container { position:absolute; left:12px; top:56px; width: 220px; z-index: 900; }
-.mini-map { background: var(--surface-card); border: 1px solid var(--border-strong); border-radius: var(--radius-card); padding: 8px; }
-.mini-map-title { color: var(--text-secondary); font-size: 12px; margin-bottom: 8px; }
-.mini-map-viewport { position: relative; width: 100%; height: 120px; border: 2px solid var(--border-strong); background: var(--surface-overlay-04); border-radius: 8px; overflow:hidden; }
-.mini-map-rect { position:absolute; border: 2px solid var(--accent-brand); background: color-mix(in srgb, var(--accent-brand) 18%, transparent); box-shadow: 0 0 0 1px rgba(0,0,0,0.2), inset 0 0 0 1px var(--border-subtle); border-radius: 6px; }
+/* Legend Panel (replaces MiniMap) */
+.graph-minimap-container { position:absolute; left:12px; top:56px; width: 200px; z-index: 900; }
+.mini-map { background: var(--surface-card); border: 1px solid var(--border-strong); border-radius: var(--radius-card); padding: 6px; }
+.mini-map-title { color: var(--text-secondary); font-size: 11px; margin-bottom: 6px; }
+.legend-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.legend-grid-2 { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px 8px; }
+.legend-item { display: flex; align-items: center; gap: 6px; }
+.legend-item-sm { gap: 6px; }
+.legend-swatch { width: 14px; height: 14px; border-radius: 4px; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.35); }
+.legend-swatch-sm { width: 12px; height: 12px; }
+.legend-label { font-size: 12px; color: var(--text-secondary); }
+.legend-label-sm { font-size: 11px; }
 
 /* Impact banner */
 .banner-impact {


### PR DESCRIPTION
This pull request introduces several improvements to the dependency graph visualization, focusing on filtering, external module handling, and UI enhancements. The main changes include a new product requirements document (PRD) for file-type filter chips, refined exclusion of external modules from the graph, and UI updates to the file info panel and focus/impact breadcrumbs. Below are the most important changes grouped by theme:

**Feature Design & Documentation**

* Added a comprehensive PRD (`filter-chip-prd.md`) specifying the design, requirements, UX, and implementation plan for file-type filter chips in the graph view. This will guide the development of interactive filtering by file type, integrated with Focus and Impact modes, and includes accessibility and performance considerations.

**Dependency Graph Filtering and Data Handling**

* Enhanced the dependency-cruiser CLI arguments to exclude Node.js core modules, bare package specifiers (e.g., 'react'), and external folders from the scan. This prevents external or irrelevant modules from appearing in the graph.
* Updated the graph data transformation logic to robustly filter out external modules (Node.js core, bare specifiers, node_modules, and files outside the workspace) when building the graph, ensuring only relevant workspace files are visualized. [[1]](diffhunk://#diff-a0c2cab8181be71aff6f68b0852ce23a68a14fd7dc95a7a21eda5c083bbe8427R4) [[2]](diffhunk://#diff-a0c2cab8181be71aff6f68b0852ce23a68a14fd7dc95a7a21eda5c083bbe8427R116-R151) [[3]](diffhunk://#diff-a0c2cab8181be71aff6f68b0852ce23a68a14fd7dc95a7a21eda5c083bbe8427L136-R170)

**UI Improvements**

* Improved the `FileInfoPanel` to display only workspace-relative paths for nodes, and clearly label nodes that are outside the workspace or are absolute paths, enhancing clarity for users inspecting node details. [[1]](diffhunk://#diff-2991347ece73a3ea6e10966ca65b3ee03017b21b09bde73f10dc4f0ab882dd27L38-R44) [[2]](diffhunk://#diff-2991347ece73a3ea6e10966ca65b3ee03017b21b09bde73f10dc4f0ab882dd27L51-R57)
* Extended the `FocusBreadcrumb` component to show an Impact label and a "Reset Impact" button when in Impact View, providing better context and control for users navigating focus and impact states. [[1]](diffhunk://#diff-cdf216a0b34fab8ac064dca86bbde36965ee51f0b25e186d9ead657b707895a7R13-R17) [[2]](diffhunk://#diff-cdf216a0b34fab8ac064dca86bbde36965ee51f0b25e186d9ead657b707895a7L29-R31) [[3]](diffhunk://#diff-cdf216a0b34fab8ac064dca86bbde36965ee51f0b25e186d9ead657b707895a7R40-R64)

**Graph Interaction & Performance**

* Refactored `GraphDashboard` to use a new `applyFocus` helper, which applies focus and visibility to the graph canvas in a consistent way, aligning visible edges and centering on the root node. This improves the reliability and maintainability of focus/impact transitions. [[1]](diffhunk://#diff-e8fa683bb1940629cfaeaeee3223677924c2332ee2844ecd34148f22f6a57ab4R124-R125) [[2]](diffhunk://#diff-e8fa683bb1940629cfaeaeee3223677924c2332ee2844ecd34148f22f6a57ab4R167-R189) [[3]](diffhunk://#diff-e8fa683bb1940629cfaeaeee3223677924c2332ee2844ecd34148f22f6a57ab4L287-R314) [[4]](diffhunk://#diff-e8fa683bb1940629cfaeaeee3223677924c2332ee2844ecd34148f22f6a57ab4L339-R364)